### PR TITLE
Fixed Fibonacci

### DIFF
--- a/emotinomicon.js
+++ b/emotinomicon.js
@@ -12,7 +12,7 @@ function arithmeticException(name){
 	this.name=name;
 }
 function fibonacci(n){
-	if(n>0){
+	if(n<0){
 		return -1;
 	}
 	if(n==0){


### PR DESCRIPTION
In the old version the comparison operator was the wrong direction so that the function always returned -1 if `n>1` instead of `n<1`
